### PR TITLE
Enable travis-ci build validation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+dist: trusty
+before_install:
+  - sudo apt-get update -qq
+install:
+  - sudo apt-get install -qq gcc-avr binutils-avr avr-libc
+script: make
+


### PR DESCRIPTION
Build automation is great! Although I haven't used travis-ci to manage artifacts, I'm sure it could do that as well if you want to automate building the hex files.

If you like this I can go ahead and set it up to build with various combination's of feature flags enabled. I'm not exactly sure that would work though since flags are set in `config.h` instead of `-DCONFIG_FLAG`.

After including `.travis.yml` in the project root you need to setup the github/travis integration, then it looks like this:
https://travis-ci.org/winder/grbl/builds/169346973
