### PR TITLE
Servo support added (switchable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ _This is a special version with servo support instead of spindle/laser PWM_
 - The pulse width range is 0.63ms to 2.2ms
 - S0 does not deactivate the PWM, but instead send min pulse width
 - Set the max. S-value to `$30=255` to get a S-value range of 0-255
-- You should have a M3S0 at the start of your gcode to activate the servo and M5 at end to deactivate it  
+- You should have a M3S0 at the start of your gcode to activate the servo and M5 at end to deactivate it
+
 ***
 
 Grbl is a no-compromise, high performance, low cost alternative to parallel-port-based motion control for CNC milling. This version of Grbl runs on an Arduino with a 328p processor (Uno, Duemilanove, Nano, Micro, etc).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 ![GitHub Logo](/doc/media/Grbl Logo 250px.png)
 ***
 _This is a special version with servo support instead of spindle/laser PWM_
+
+- The PWM frequency is set to 62.5Hz (prescaler 1/1024)
+- The pulse width range is 0.63ms to 2.2ms
+- S0 does not deactivate the PWM, but instead send min pulse width
+- Set the max. S-value to `$30=255` to get a S-value range of 0-255
+- You should have a M3S0 at the start of your gcode to activate the servo and M5 at end to deactivate it  
 ***
+
 Grbl is a no-compromise, high performance, low cost alternative to parallel-port-based motion control for CNC milling. This version of Grbl runs on an Arduino with a 328p processor (Uno, Duemilanove, Nano, Micro, etc).
 
 The controller is written in highly optimized C utilizing every clever feature of the AVR-chips to achieve precise timing and asynchronous operation. It is able to maintain up to 30kHz of stable, jitter free control pulses.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![GitHub Logo](/doc/media/Grbl Logo 250px.png)
 ***
-_Click the `Release` tab to download pre-compiled `.hex` files or just [click here](https://github.com/gnea/grbl/releases)_
+_This is a special version with servo support instead of spindle/laser PWM_
 ***
 Grbl is a no-compromise, high performance, low cost alternative to parallel-port-based motion control for CNC milling. This version of Grbl runs on an Arduino with a 328p processor (Uno, Duemilanove, Nano, Micro, etc).
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ![GitHub Logo](/doc/media/Grbl Logo 250px.png)
 ***
-_This is a special version with servo support instead of spindle/laser PWM_
+_This is a special version with servo support (swichable in config.h)_
 
-- The PWM frequency is set to 62.5Hz (prescaler 1/1024)
-- The pulse width range is 0.63ms to 2.2ms
-- S0 does not deactivate the PWM, but instead send min pulse width
-- Set the max. S-value to `$30=255` to get a S-value range of 0-255
-- You should have a M3S0 at the start of your gcode to activate the servo and M5 at end to deactivate it
+- The PWM frequency is set to 61Hz (prescaler 1/1024).
+- The pulse width range is 0.5 - 2.5ms.
+- S0 does not deactivate the PWM, but instead send min pulse width.
+- Set the max. S-value to `$30=255` to get a S-value range of 0-255.
+- You should have a M3S0 at the start of your gcode to activate the servo and M5 at end to deactivate it.
 
 ***
 

--- a/grbl/config.h
+++ b/grbl/config.h
@@ -102,15 +102,16 @@
 // on separate pin, but homed in one cycle. Also, it should be noted that the function of hard limits
 // will not be affected by pin sharing.
 // NOTE: Defaults are set for a traditional 3-axis CNC machine. Z-axis first to clear, followed by X & Y.
-#define HOMING_CYCLE_0 (1<<Z_AXIS)                // REQUIRED: First move Z to clear workspace.
-#define HOMING_CYCLE_1 ((1<<X_AXIS)|(1<<Y_AXIS))  // OPTIONAL: Then move X,Y at the same time.
-// #define HOMING_CYCLE_2                         // OPTIONAL: Uncomment and add axes mask to enable
+//#define HOMING_CYCLE_0 (1<<Z_AXIS)                // REQUIRED: First move Z to clear workspace.
+//#define HOMING_CYCLE_1 ((1<<X_AXIS)|(1<<Y_AXIS))  // OPTIONAL: Then move X,Y at the same time.
+//#define HOMING_CYCLE_2                          // OPTIONAL: Uncomment and add axes mask to enable
 
 // NOTE: The following are two examples to setup homing for 2-axis machines.
-// #define HOMING_CYCLE_0 ((1<<X_AXIS)|(1<<Y_AXIS))  // NOT COMPATIBLE WITH COREXY: Homes both X-Y in one cycle. 
+#define HOMING_CYCLE_0 ((1<<X_AXIS)|(1<<Y_AXIS))  // NOT COMPATIBLE WITH COREXY: Homes both X-Y in one cycle. 
+//#define HOMING_CYCLE_0 ((1<<Y_AXIS))  // EggBot: Home Y axis only.
 
-// #define HOMING_CYCLE_0 (1<<X_AXIS)  // COREXY COMPATIBLE: First home X
-// #define HOMING_CYCLE_1 (1<<Y_AXIS)  // COREXY COMPATIBLE: Then home Y
+//#define HOMING_CYCLE_0 (1<<X_AXIS)  // COREXY COMPATIBLE: First home X
+//#define HOMING_CYCLE_1 (1<<Y_AXIS)  // COREXY COMPATIBLE: Then home Y
 
 // Number of homing cycles performed after when the machine initially jogs to limit switches.
 // This help in preventing overshoot and should improve repeatability. This value should be one or
@@ -121,12 +122,15 @@
 // cycle is still invoked by the $H command. This is disabled by default. It's here only to address
 // users that need to switch between a two-axis and three-axis machine. This is actually very rare.
 // If you have a two-axis machine, DON'T USE THIS. Instead, just alter the homing cycle for two-axes.
-// #define HOMING_SINGLE_AXIS_COMMANDS // Default disabled. Uncomment to enable.
+#define HOMING_SINGLE_AXIS_COMMANDS // Default disabled. Uncomment to enable.
 
 // After homing, Grbl will set by default the entire machine space into negative space, as is typical
 // for professional CNC machines, regardless of where the limit switches are located. Uncomment this
 // define to force Grbl to always set the machine origin at the homed location despite switch orientation.
-// #define HOMING_FORCE_SET_ORIGIN // Uncomment to enable.
+//#define HOMING_FORCE_SET_ORIGIN // Uncomment to enable.
+
+// Uncomment this define to force Grbl to always set the machine origin at bottom left.
+#define HOMING_FORCE_POSITIVE_SPACE // Uncomment to enable.
 
 // Number of blocks Grbl executes upon startup. These blocks are stored in EEPROM, where the size
 // and addresses are defined in settings.h. With the current settings, up to 2 startup blocks may

--- a/grbl/config.h
+++ b/grbl/config.h
@@ -367,6 +367,11 @@
 // NOTE: Requires USE_SPINDLE_DIR_AS_ENABLE_PIN to be enabled.
 // #define SPINDLE_ENABLE_OFF_WITH_ZERO_SPEED // Default disabled. Uncomment to enable.
 
+// If you use a servo instead of a spindle (like on EggBot or pen plotter), you need to uncomment this option. 
+// This will set the PWM frequency to 61Hz and limit the PWM range to 0.5 - 2.5ms, as used by most servos.
+// See cpu_map.h, if you need to change the PWM range.
+#define SPINDLE_IS_SERVO // Default disabled. Uncomment to enable.
+
 // With this enabled, Grbl sends back an echo of the line it has received, which has been pre-parsed (spaces
 // removed, capitalized letters, no comments) and is to be immediately executed by Grbl. Echoes will not be
 // sent upon a line buffer overflow, but should for all normal lines sent to Grbl. For example, if a user

--- a/grbl/cpu_map.h
+++ b/grbl/cpu_map.h
@@ -124,11 +124,18 @@
 
   // Variable spindle configuration below. Do not change unless you know what you are doing.
   // NOTE: Only used when variable spindle is enabled.
-  #define SPINDLE_PWM_MAX_VALUE     35   // Don't change. 328p fast PWM mode fixes top value as 255.
-  #ifndef SPINDLE_PWM_MIN_VALUE
-    #define SPINDLE_PWM_MIN_VALUE   10   // Must be greater than zero.
+  #ifdef SPINDLE_IS_SERVO
+    #define SPINDLE_PWM_MAX_VALUE     38  // set max pulse duration to 2.5ms
+    #ifndef SPINDLE_PWM_MIN_VALUE
+      #define SPINDLE_PWM_MIN_VALUE   7   // set min pulse duration to 0.5ms
+    #endif
+  #else
+    #define SPINDLE_PWM_MAX_VALUE     255  // Don't change. 328p fast PWM mode fixes top value as 255.
+    #ifndef SPINDLE_PWM_MIN_VALUE
+      #define SPINDLE_PWM_MIN_VALUE   1    // Must be greater than zero.
+    #endif
   #endif
-  #define SPINDLE_PWM_OFF_VALUE     -1
+  #define SPINDLE_PWM_OFF_VALUE     0
   #define SPINDLE_PWM_RANGE         (SPINDLE_PWM_MAX_VALUE-SPINDLE_PWM_MIN_VALUE)
   #define SPINDLE_TCCRA_REGISTER	  TCCR2A
   #define SPINDLE_TCCRB_REGISTER	  TCCR2B
@@ -137,11 +144,14 @@
 
   // Prescaled, 8-bit Fast PWM mode.
   #define SPINDLE_TCCRA_INIT_MASK   ((1<<WGM20) | (1<<WGM21))  // Configures fast PWM mode.
-  // #define SPINDLE_TCCRB_INIT_MASK   (1<<CS20)               // Disable prescaler -> 62.5kHz
-  // #define SPINDLE_TCCRB_INIT_MASK   (1<<CS21)               // 1/8 prescaler -> 7.8kHz (Used in v0.9)
-  // #define SPINDLE_TCCRB_INIT_MASK   ((1<<CS21) | (1<<CS20)) // 1/32 prescaler -> 1.96kHz
-  // #define SPINDLE_TCCRB_INIT_MASK   (1<<CS22)               // 1/64 prescaler -> 0.98kHz (J-tech laser)
-  #define SPINDLE_TCCRB_INIT_MASK      ((1<<CS22) | (1<<CS21) | (1<<CS20)) // 1/(1024) prescaler -> 62.5Hz (Servo)
+  #ifdef SPINDLE_IS_SERVO
+    #define SPINDLE_TCCRB_INIT_MASK      ((1<<CS22) | (1<<CS21) | (1<<CS20)) // 1/1024 prescaler -> 61Hz (for Servo)
+  #else
+    // #define SPINDLE_TCCRB_INIT_MASK   (1<<CS20)               // Disable prescaler -> 62.5kHz
+    // #define SPINDLE_TCCRB_INIT_MASK   (1<<CS21)               // 1/8 prescaler -> 7.8kHz (Used in v0.9)
+    // #define SPINDLE_TCCRB_INIT_MASK   ((1<<CS21) | (1<<CS20)) // 1/32 prescaler -> 1.96kHz
+    #define SPINDLE_TCCRB_INIT_MASK   (1<<CS22)               // 1/64 prescaler -> 0.98kHz (J-tech laser)
+  #endif
 
   // NOTE: On the 328p, these must be the same as the SPINDLE_ENABLE settings.
   #define SPINDLE_PWM_DDR	  DDRB

--- a/grbl/cpu_map.h
+++ b/grbl/cpu_map.h
@@ -124,11 +124,11 @@
 
   // Variable spindle configuration below. Do not change unless you know what you are doing.
   // NOTE: Only used when variable spindle is enabled.
-  #define SPINDLE_PWM_MAX_VALUE     255 // Don't change. 328p fast PWM mode fixes top value as 255.
+  #define SPINDLE_PWM_MAX_VALUE     35   // Don't change. 328p fast PWM mode fixes top value as 255.
   #ifndef SPINDLE_PWM_MIN_VALUE
-    #define SPINDLE_PWM_MIN_VALUE   1   // Must be greater than zero.
+    #define SPINDLE_PWM_MIN_VALUE   10   // Must be greater than zero.
   #endif
-  #define SPINDLE_PWM_OFF_VALUE     0
+  #define SPINDLE_PWM_OFF_VALUE     -1
   #define SPINDLE_PWM_RANGE         (SPINDLE_PWM_MAX_VALUE-SPINDLE_PWM_MIN_VALUE)
   #define SPINDLE_TCCRA_REGISTER	  TCCR2A
   #define SPINDLE_TCCRB_REGISTER	  TCCR2B
@@ -140,7 +140,8 @@
   // #define SPINDLE_TCCRB_INIT_MASK   (1<<CS20)               // Disable prescaler -> 62.5kHz
   // #define SPINDLE_TCCRB_INIT_MASK   (1<<CS21)               // 1/8 prescaler -> 7.8kHz (Used in v0.9)
   // #define SPINDLE_TCCRB_INIT_MASK   ((1<<CS21) | (1<<CS20)) // 1/32 prescaler -> 1.96kHz
-  #define SPINDLE_TCCRB_INIT_MASK      (1<<CS22)               // 1/64 prescaler -> 0.98kHz (J-tech laser)
+  // #define SPINDLE_TCCRB_INIT_MASK   (1<<CS22)               // 1/64 prescaler -> 0.98kHz (J-tech laser)
+  #define SPINDLE_TCCRB_INIT_MASK      ((1<<CS22) | (1<<CS21) | (1<<CS20)) // 1/(1024) prescaler -> 62.5Hz (Servo)
 
   // NOTE: On the 328p, these must be the same as the SPINDLE_ENABLE settings.
   #define SPINDLE_PWM_DDR	  DDRB

--- a/grbl/limits.c
+++ b/grbl/limits.c
@@ -307,9 +307,17 @@ void limits_go_home(uint8_t cycle_mask)
         set_axis_position = 0;
       #else
         if ( bit_istrue(settings.homing_dir_mask,bit(idx)) ) {
-          set_axis_position = lround((settings.max_travel[idx]+settings.homing_pulloff)*settings.steps_per_mm[idx]);
+          #ifdef HOMING_FORCE_POSITIVE_SPACE
+            set_axis_position = 0; //lround(settings.homing_pulloff*settings.steps_per_mm[idx]);
+          #else
+            set_axis_position = lround((settings.max_travel[idx]+settings.homing_pulloff)*settings.steps_per_mm[idx]);
+          #endif
         } else {
-          set_axis_position = lround(-settings.homing_pulloff*settings.steps_per_mm[idx]);
+          #ifdef HOMING_FORCE_POSITIVE_SPACE
+            set_axis_position = lround((-settings.max_travel[idx]-settings.homing_pulloff)*settings.steps_per_mm[idx]);
+          #else
+            set_axis_position = lround(-settings.homing_pulloff*settings.steps_per_mm[idx]);
+          #endif
         }
       #endif
 

--- a/grbl/spindle_control.c
+++ b/grbl/spindle_control.c
@@ -141,20 +141,27 @@ void spindle_stop()
   uint8_t spindle_compute_pwm_value(float rpm) // 328p PWM register is 8-bit.
   {
     uint8_t pwm_value;
-    rpm *= (0.010*sys.spindle_speed_ovr); // Scale by spindle speed override value.
+    #ifndef SPINDLE_IS_SERVO
+      rpm *= (0.010*sys.spindle_speed_ovr); // Scale by spindle speed override value.
+    #endif
     // Calculate PWM register value based on rpm max/min settings and programmed rpm.
     if ((settings.rpm_min >= settings.rpm_max) || (rpm >= settings.rpm_max)) {
       // No PWM range possible. Set simple on/off spindle control pin state.
       sys.spindle_speed = settings.rpm_max;
       pwm_value = SPINDLE_PWM_MAX_VALUE;
     } else if (rpm <= settings.rpm_min) {
-//      if (rpm == 0.0) { // S0 disables spindle
-//        sys.spindle_speed = 0.0;
-//        pwm_value = SPINDLE_PWM_OFF_VALUE;
-//      } else { // Set minimum PWM output
+      if (rpm == 0.0) { // S0 disables spindle
+        #ifndef SPINDLE_IS_SERVO
+          sys.spindle_speed = 0.0;
+          pwm_value = SPINDLE_PWM_OFF_VALUE;
+        #else
+          sys.spindle_speed = settings.rpm_min;
+          pwm_value = SPINDLE_PWM_MIN_VALUE;
+        #endif
+      } else { // Set minimum PWM output
         sys.spindle_speed = settings.rpm_min;
         pwm_value = SPINDLE_PWM_MIN_VALUE;
-//      }
+      }
     } else { 
       // Compute intermediate PWM value with linear spindle speed model.
       // NOTE: A nonlinear model could be installed here, if required, but keep it VERY light-weight.
@@ -179,9 +186,17 @@ void spindle_stop()
   if (state == SPINDLE_DISABLE) { // Halt or set spindle direction and rpm.
   
     #ifdef VARIABLE_SPINDLE
-      sys.spindle_speed = 0.0;
+      #ifndef SPINDLE_IS_SERVO
+        sys.spindle_speed = 0.0;
+        spindle_stop();
+      #else
+        // For servo send min. PWM instead of deactivate PWM
+        sys.spindle_speed = SPINDLE_PWM_MIN_VALUE;
+        spindle_set_speed(spindle_compute_pwm_value(SPINDLE_PWM_MIN_VALUE));      
+      #endif
+    #else
+      spindle_stop();
     #endif
-    spindle_stop();
   
   } else {
   

--- a/grbl/spindle_control.c
+++ b/grbl/spindle_control.c
@@ -59,28 +59,28 @@ void spindle_init()
 uint8_t spindle_get_state()
 {
 	#ifdef VARIABLE_SPINDLE
-    #ifdef USE_SPINDLE_DIR_AS_ENABLE_PIN
-		  // No spindle direction output pin. 
-			#ifdef INVERT_SPINDLE_ENABLE_PIN
-			  if (bit_isfalse(SPINDLE_ENABLE_PORT,(1<<SPINDLE_ENABLE_BIT))) { return(SPINDLE_STATE_CW); }
-	    #else
-	 			if (bit_istrue(SPINDLE_ENABLE_PORT,(1<<SPINDLE_ENABLE_BIT))) { return(SPINDLE_STATE_CW); }
-	    #endif
-    #else
-      if (SPINDLE_TCCRA_REGISTER & (1<<SPINDLE_COMB_BIT)) { // Check if PWM is enabled.
-        if (SPINDLE_DIRECTION_PORT & (1<<SPINDLE_DIRECTION_BIT)) { return(SPINDLE_STATE_CCW); }
-        else { return(SPINDLE_STATE_CW); }
-      }
-    #endif
+        #ifdef USE_SPINDLE_DIR_AS_ENABLE_PIN
+              // No spindle direction output pin. 
+            #ifdef INVERT_SPINDLE_ENABLE_PIN
+                if (bit_isfalse(SPINDLE_ENABLE_PORT,(1<<SPINDLE_ENABLE_BIT))) { return(SPINDLE_STATE_CW); }
+            #else
+                if (bit_istrue(SPINDLE_ENABLE_PORT,(1<<SPINDLE_ENABLE_BIT))) { return(SPINDLE_STATE_CW); }
+            #endif
+        #else
+            if (SPINDLE_TCCRA_REGISTER & (1<<SPINDLE_COMB_BIT)) { // Check if PWM is enabled.
+                if (SPINDLE_DIRECTION_PORT & (1<<SPINDLE_DIRECTION_BIT)) { return(SPINDLE_STATE_CCW); }
+                else { return(SPINDLE_STATE_CW); }
+            }
+        #endif
 	#else
 		#ifdef INVERT_SPINDLE_ENABLE_PIN
-		  if (bit_isfalse(SPINDLE_ENABLE_PORT,(1<<SPINDLE_ENABLE_BIT))) { 
+            if (bit_isfalse(SPINDLE_ENABLE_PORT,(1<<SPINDLE_ENABLE_BIT))) { 
 		#else
-		  if (bit_istrue(SPINDLE_ENABLE_PORT,(1<<SPINDLE_ENABLE_BIT))) {
+            if (bit_istrue(SPINDLE_ENABLE_PORT,(1<<SPINDLE_ENABLE_BIT))) {
 		#endif
-      if (SPINDLE_DIRECTION_PORT & (1<<SPINDLE_DIRECTION_BIT)) { return(SPINDLE_STATE_CCW); }
-      else { return(SPINDLE_STATE_CW); }
-    }
+                if (SPINDLE_DIRECTION_PORT & (1<<SPINDLE_DIRECTION_BIT)) { return(SPINDLE_STATE_CCW); }
+                else { return(SPINDLE_STATE_CW); }
+            }
 	#endif
 	return(SPINDLE_STATE_DISABLE);
 }
@@ -91,22 +91,22 @@ uint8_t spindle_get_state()
 // Called by spindle_init(), spindle_set_speed(), spindle_set_state(), and mc_reset().
 void spindle_stop()
 {
-  #ifdef VARIABLE_SPINDLE
-    SPINDLE_TCCRA_REGISTER &= ~(1<<SPINDLE_COMB_BIT); // Disable PWM. Output voltage is zero.
-    #ifdef USE_SPINDLE_DIR_AS_ENABLE_PIN
-      #ifdef INVERT_SPINDLE_ENABLE_PIN
-        SPINDLE_ENABLE_PORT |= (1<<SPINDLE_ENABLE_BIT);  // Set pin to high
-      #else
-        SPINDLE_ENABLE_PORT &= ~(1<<SPINDLE_ENABLE_BIT); // Set pin to low
-      #endif
-    #endif
-  #else
-    #ifdef INVERT_SPINDLE_ENABLE_PIN
-      SPINDLE_ENABLE_PORT |= (1<<SPINDLE_ENABLE_BIT);  // Set pin to high
+    #ifdef VARIABLE_SPINDLE
+        SPINDLE_TCCRA_REGISTER &= ~(1<<SPINDLE_COMB_BIT); // Disable PWM. Output voltage is zero.
+        #ifdef USE_SPINDLE_DIR_AS_ENABLE_PIN
+            #ifdef INVERT_SPINDLE_ENABLE_PIN
+                SPINDLE_ENABLE_PORT |= (1<<SPINDLE_ENABLE_BIT);  // Set pin to high
+            #else
+                SPINDLE_ENABLE_PORT &= ~(1<<SPINDLE_ENABLE_BIT); // Set pin to low
+            #endif
+        #endif
     #else
-      SPINDLE_ENABLE_PORT &= ~(1<<SPINDLE_ENABLE_BIT); // Set pin to low
+        #ifdef INVERT_SPINDLE_ENABLE_PIN
+            SPINDLE_ENABLE_PORT |= (1<<SPINDLE_ENABLE_BIT);  // Set pin to high
+        #else
+            SPINDLE_ENABLE_PORT &= ~(1<<SPINDLE_ENABLE_BIT); // Set pin to low
+        #endif
     #endif
-  #endif
 }
 
 
@@ -148,13 +148,13 @@ void spindle_stop()
       sys.spindle_speed = settings.rpm_max;
       pwm_value = SPINDLE_PWM_MAX_VALUE;
     } else if (rpm <= settings.rpm_min) {
-      if (rpm == 0.0) { // S0 disables spindle
-        sys.spindle_speed = 0.0;
-        pwm_value = SPINDLE_PWM_OFF_VALUE;
-      } else { // Set minimum PWM output
+//      if (rpm == 0.0) { // S0 disables spindle
+//        sys.spindle_speed = 0.0;
+//        pwm_value = SPINDLE_PWM_OFF_VALUE;
+//      } else { // Set minimum PWM output
         sys.spindle_speed = settings.rpm_min;
         pwm_value = SPINDLE_PWM_MIN_VALUE;
-      }
+//      }
     } else { 
       // Compute intermediate PWM value with linear spindle speed model.
       // NOTE: A nonlinear model could be installed here, if required, but keep it VERY light-weight.

--- a/grbl/system.c
+++ b/grbl/system.c
@@ -342,7 +342,11 @@ uint8_t system_check_travel_limits(float *target)
       }
     #else
       // NOTE: max_travel is stored as negative
-      if (target[idx] > 0 || target[idx] < settings.max_travel[idx]) { return(true); }
+      #ifdef HOMING_FORCE_POSITIVE_SPACE
+        if (target[idx] < 0 || target[idx] > -settings.max_travel[idx]) { return(true); }
+      #else
+        if (target[idx] > 0 || target[idx] < settings.max_travel[idx]) { return(true); }
+      #endif
     #endif
   }
   return(false);


### PR DESCRIPTION
Hi Sonny

I have implemented support for servo instead of spindle (for EggBot). It's switchable by `#define SPINDLE_IS_SERVO` in config.h. 
This defines a prescaler of 1/1024 (61Hz) and min/max PWM values for a pulse duration between 0.5 and 2.5ms in cpu_map.h.
In spindle_control.c I modified the function spindle_compute_pwm_value: If SPINDLE_IS_SERVO is defined, don't calc spindle override and use min PWM instead of stop_spindle. 

I have tested it with an EggBot and LaserWeb3 and 4.

Hope this is usefull for you.

Regards Claudio