### PR TITLE
Invert VARIABLE_SPINDLE PWM output

### DIFF
--- a/grbl/config.h
+++ b/grbl/config.h
@@ -210,6 +210,9 @@
 // uncomment the config option USE_SPINDLE_DIR_AS_ENABLE_PIN below.
 // #define INVERT_SPINDLE_ENABLE_PIN // Default disabled. Uncomment to enable.
 
+// Invert the PWM signal for VARIABLE_SPINDLE
+// #define INVERT_SPINDLE_PWM // Disabled by default. Uncomment to enable.
+
 // Inverts the selected coolant pin from low-disabled/high-enabled to low-enabled/high-disabled. Useful
 // for some pre-built electronic boards.
 // #define INVERT_COOLANT_FLOOD_PIN // Default disabled. Uncomment to enable.

--- a/grbl/cpu_map.h
+++ b/grbl/cpu_map.h
@@ -137,6 +137,11 @@
 
   // Prescaled, 8-bit Fast PWM mode.
   #define SPINDLE_TCCRA_INIT_MASK   ((1<<WGM20) | (1<<WGM21))  // Configures fast PWM mode.
+  #ifdef INVERT_SPINDLE_PWM
+    #define SPINDLE_TCCRA_ENABLE_PWM_MASK ((1<<COM2A1) | (1<<COM2A0))  // Inverts PWM output signal
+  #else
+     #define SPINDLE_TCCRA_ENABLE_PWM_MASK (1<<COM2A1)
+   #endif
   // #define SPINDLE_TCCRB_INIT_MASK   (1<<CS20)               // Disable prescaler -> 62.5kHz
   // #define SPINDLE_TCCRB_INIT_MASK   (1<<CS21)               // 1/8 prescaler -> 7.8kHz (Used in v0.9)
   // #define SPINDLE_TCCRB_INIT_MASK   ((1<<CS21) | (1<<CS20)) // 1/32 prescaler -> 1.96kHz

--- a/grbl/spindle_control.c
+++ b/grbl/spindle_control.c
@@ -67,7 +67,7 @@ uint8_t spindle_get_state()
 	 			if (bit_istrue(SPINDLE_ENABLE_PORT,(1<<SPINDLE_ENABLE_BIT))) { return(SPINDLE_STATE_CW); }
 	    #endif
     #else
-      if (SPINDLE_TCCRA_REGISTER & (1<<SPINDLE_COMB_BIT)) { // Check if PWM is enabled.
+      if (SPINDLE_TCCRA_REGISTER & (SPINDLE_TCCRA_ENABLE_PWM_MASK)) { // Check if PWM is enabled.
         if (SPINDLE_DIRECTION_PORT & (1<<SPINDLE_DIRECTION_BIT)) { return(SPINDLE_STATE_CCW); }
         else { return(SPINDLE_STATE_CW); }
       }
@@ -92,7 +92,7 @@ uint8_t spindle_get_state()
 void spindle_stop()
 {
   #ifdef VARIABLE_SPINDLE
-    SPINDLE_TCCRA_REGISTER &= ~(1<<SPINDLE_COMB_BIT); // Disable PWM. Output voltage is zero.
+    SPINDLE_TCCRA_REGISTER &= ~(SPINDLE_TCCRA_ENABLE_PWM_MASK); // Disable PWM. Output voltage is zero.
     #ifdef USE_SPINDLE_DIR_AS_ENABLE_PIN
       #ifdef INVERT_SPINDLE_ENABLE_PIN
         SPINDLE_ENABLE_PORT |= (1<<SPINDLE_ENABLE_BIT);  // Set pin to high
@@ -120,7 +120,7 @@ void spindle_stop()
       if (pwm_value == SPINDLE_PWM_OFF_VALUE) {
         spindle_stop();
       } else {
-        SPINDLE_TCCRA_REGISTER |= (1<<SPINDLE_COMB_BIT); // Ensure PWM output is enabled.
+        SPINDLE_TCCRA_REGISTER |= (SPINDLE_TCCRA_ENABLE_PWM_MASK); // Ensure PWM output is enabled.
         #ifdef INVERT_SPINDLE_ENABLE_PIN
           SPINDLE_ENABLE_PORT &= ~(1<<SPINDLE_ENABLE_BIT);
         #else
@@ -129,9 +129,9 @@ void spindle_stop()
       }
     #else
       if (pwm_value == SPINDLE_PWM_OFF_VALUE) {
-        SPINDLE_TCCRA_REGISTER &= ~(1<<SPINDLE_COMB_BIT); // Disable PWM. Output voltage is zero.
+        SPINDLE_TCCRA_REGISTER &= ~(SPINDLE_TCCRA_ENABLE_PWM_MASK); // Disable PWM. Output voltage is zero.
       } else {
-        SPINDLE_TCCRA_REGISTER |= (1<<SPINDLE_COMB_BIT); // Ensure PWM output is enabled.
+        SPINDLE_TCCRA_REGISTER |= (SPINDLE_TCCRA_ENABLE_PWM_MASK); // Ensure PWM output is enabled.
       }
     #endif
   }


### PR DESCRIPTION
Adds the option to invert the duty cycle of the variable speed spindle output pin.
Tested with VFD Controller (Huanyang Invertor Model: HY01D523B)