### PR TITLE
Fix duplicate #defines in nuts_bolts.h

### DIFF
--- a/grbl/nuts_bolts.h
+++ b/grbl/nuts_bolts.h
@@ -22,8 +22,12 @@
 #ifndef nuts_bolts_h
 #define nuts_bolts_h
 
-#define false 0
-#define true 1
+#if false
+	#define false 0
+#endif
+#ifndef true
+	#define true 1
+#endif
 
 #define SOME_LARGE_VALUE 1.0E+38
 
@@ -53,12 +57,18 @@
 #define clear_vector(a) memset(a, 0, sizeof(a))
 #define clear_vector_float(a) memset(a, 0.0, sizeof(float)*N_AXIS)
 // #define clear_vector_long(a) memset(a, 0.0, sizeof(long)*N_AXIS)
-#define max(a,b) (((a) > (b)) ? (a) : (b))
-#define min(a,b) (((a) < (b)) ? (a) : (b))
+#ifndef max
+	#define max(a,b) (((a) > (b)) ? (a) : (b))
+#endif
+#ifndef min
+	#define min(a,b) (((a) < (b)) ? (a) : (b))
+#endif
 #define isequal_position_vector(a,b) !(memcmp(a, b, sizeof(float)*N_AXIS))
 
 // Bit field and masking macros
-#define bit(n) (1 << n)
+#ifndef bit
+	#define bit(n) (1 << n)
+#endif
 #define bit_true(x,mask) (x) |= (mask)
 #define bit_false(x,mask) (x) &= ~(mask)
 #define bit_istrue(x,mask) ((x & mask) != 0)


### PR DESCRIPTION
These throw compiler warnings for me with avr-gcc/4.9.2-atmel3.5.4-arduino2 as they are already defined in arduino/hardware/avr/1.6.21/cores/arduino/Arduino.h