### PR TITLE
Fix Issue #468: Failure to restore mist output (M7) after door open event and cycle start

### DIFF
--- a/grbl/protocol.c
+++ b/grbl/protocol.c
@@ -680,7 +680,7 @@ static void protocol_exec_rt_suspend()
               // Block if safety door re-opened during prior restore actions.
               if (bit_isfalse(sys.suspend,SUSPEND_RESTART_RETRACT)) {
                 // NOTE: Laser mode will honor this delay. An exhaust system is often controlled by this pin.
-                coolant_set_state((restore_condition & (PL_COND_FLAG_COOLANT_FLOOD | PL_COND_FLAG_COOLANT_FLOOD)));
+                coolant_set_state((restore_condition & (PL_COND_FLAG_COOLANT_FLOOD | PL_COND_FLAG_COOLANT_MIST)));
                 delay_sec(SAFETY_DOOR_COOLANT_DELAY, DELAY_MODE_SYS_SUSPEND);
               }
             }


### PR DESCRIPTION
Fix apparent error in restore masking from protocol module that causes the call to coolant_set_state to not re-enable the mist (M7) output if it was previously enabled.

[Reported issue 468](https://github.com/gnea/grbl/issues/468)