### PR TITLE
Persist G92 and G43.1

### DIFF
--- a/grbl/gcode.h
+++ b/grbl/gcode.h
@@ -224,7 +224,7 @@ typedef struct {
                                  // position in mm. Loaded from EEPROM when called.
   float coord_offset[N_AXIS];    // Retains the G92 coordinate offset (work coordinates) relative to
                                  // machine zero in mm. Non-persistent. Cleared upon reset and boot.
-  float tool_length_offset;      // Tracks tool length offset value when enabled.
+  float tool_length_offset[N_AXIS];// Tracks tool length offset value when enabled.
 } parser_state_t;
 extern parser_state_t gc_state;
 

--- a/grbl/settings.h
+++ b/grbl/settings.h
@@ -72,11 +72,12 @@
 
 // Define EEPROM address indexing for coordinate parameters
 #define N_COORDINATE_SYSTEM 6  // Number of supported work coordinate systems (from index 1)
-#define SETTING_INDEX_NCOORD N_COORDINATE_SYSTEM+1 // Total number of system stored (from index 0)
+#define SETTING_INDEX_NCOORD N_COORDINATE_SYSTEM+3 // Total number of system stored (from index 0)
 // NOTE: Work coordinate indices are (0=G54, 1=G55, ... , 6=G59)
 #define SETTING_INDEX_G28    N_COORDINATE_SYSTEM    // Home position 1
 #define SETTING_INDEX_G30    N_COORDINATE_SYSTEM+1  // Home position 2
-// #define SETTING_INDEX_G92    N_COORDINATE_SYSTEM+2  // Coordinate offset (G92.2,G92.3 not supported)
+#define SETTING_INDEX_G92    N_COORDINATE_SYSTEM+2  // Coordinate offset
+#define SETTING_INDEX_G43    N_COORDINATE_SYSTEM+3  // Tool length
 
 // Define Grbl axis settings numbering scheme. Starts at START_VAL, every INCREMENT, over N_SETTINGS.
 #define AXIS_N_SETTINGS          4


### PR DESCRIPTION
This patch addresses issue #623 . It adds EEPROM persistence to G92 and G43.1 parameters, reduces flash consumption by approximately 150 bytes but increases RAM consumption by 8 bytes.