### PR TITLE
Do not clear G43.1 and G92 on soft-reset

### DIFF
--- a/grbl/gcode.c
+++ b/grbl/gcode.c
@@ -20,6 +20,7 @@
 */
 
 #include "grbl.h"
+#include <stddef.h>
 
 // NOTE: Max line number is defined by the g-code standard to be 99999. It seems to be an
 // arbitrary value, and some GUIs may require more. So we increased it based on a max safe
@@ -41,7 +42,7 @@ parser_block_t gc_block;
 
 void gc_init()
 {
-  memset(&gc_state, 0, sizeof(parser_state_t));
+  memset(&gc_state, 0, offsetof(parser_state_t, coord_offset));
 
   // Load default G54 coordinate system.
   if (!(settings_read_coord_data(gc_state.modal.coord_select,gc_state.coord_system))) {

--- a/grbl/gcode.h
+++ b/grbl/gcode.h
@@ -222,6 +222,8 @@ typedef struct {
 
   float coord_system[N_AXIS];    // Current work coordinate system (G54+). Stores offset from absolute machine
                                  // position in mm. Loaded from EEPROM when called.
+
+  // coord_offset and all following members retain their values during soft-resets
   float coord_offset[N_AXIS];    // Retains the G92 coordinate offset (work coordinates) relative to
                                  // machine zero in mm. Non-persistent. Cleared upon reset and boot.
   float tool_length_offset;      // Tracks tool length offset value when enabled.


### PR DESCRIPTION
Less radical approach to #623 . Just do not clear G92 and G43.1 on soft-reset. Does not change memory or flash requirements.