### PR TITLE
The pins for CNC Shield v4 which has direction and steps interchanged

### DIFF
--- a/grbl/cpu_map.h
+++ b/grbl/cpu_map.h
@@ -26,27 +26,42 @@
 #ifndef cpu_map_h
 #define cpu_map_h
 
-
 #ifdef CPU_MAP_ATMEGA328P // (Arduino Uno) Officially supported by Grbl.
 
-  // Define serial port pins and interrupt vectors.
+// Uncomment to use a CNC SHIELD v4, the one for arduino nano
+// #define CNC_SHIELD_V4
+
+// Define serial port pins and interrupt vectors.
   #define SERIAL_RX     USART_RX_vect
   #define SERIAL_UDRE   USART_UDRE_vect
 
   // Define step pulse output pins. NOTE: All step bit pins must be on the same port.
   #define STEP_DDR        DDRD
   #define STEP_PORT       PORTD
-  #define X_STEP_BIT      2  // Uno Digital Pin 2
-  #define Y_STEP_BIT      3  // Uno Digital Pin 3
-  #define Z_STEP_BIT      4  // Uno Digital Pin 4
+  #ifndef CNC_SHIELD_V4  // has traces for step and direction interchanged
+    #define X_STEP_BIT      2  // Uno Digital Pin 2
+    #define Y_STEP_BIT      3  // Uno Digital Pin 3
+    #define Z_STEP_BIT      4  // Uno Digital Pin 4
+  #else
+    #define X_STEP_BIT      5  // nano Digital Pin 5
+    #define Y_STEP_BIT      6  // nano Digital Pin 6
+    #define Z_STEP_BIT      7  // nano Digital Pin 7
+  #endif
   #define STEP_MASK       ((1<<X_STEP_BIT)|(1<<Y_STEP_BIT)|(1<<Z_STEP_BIT)) // All step bits
 
   // Define step direction output pins. NOTE: All direction pins must be on the same port.
   #define DIRECTION_DDR     DDRD
   #define DIRECTION_PORT    PORTD
-  #define X_DIRECTION_BIT   5  // Uno Digital Pin 5
-  #define Y_DIRECTION_BIT   6  // Uno Digital Pin 6
-  #define Z_DIRECTION_BIT   7  // Uno Digital Pin 7
+
+  #ifndef CNC_SHIELD_V4  // has traces for step and direction interchanged
+    #define X_DIRECTION_BIT   5  // Uno Digital Pin 5
+    #define Y_DIRECTION_BIT   6  // Uno Digital Pin 6
+    #define Z_DIRECTION_BIT   7  // Uno Digital Pin 7
+  #else
+    #define X_DIRECTION_BIT   2  // nano Digital Pin 2
+    #define Y_DIRECTION_BIT   3  // nano Digital Pin 3
+    #define Z_DIRECTION_BIT   4  // nano Digital Pin 4
+  #endif
   #define DIRECTION_MASK    ((1<<X_DIRECTION_BIT)|(1<<Y_DIRECTION_BIT)|(1<<Z_DIRECTION_BIT)) // All direction bits
 
   // Define stepper driver enable/disable output pin.


### PR DESCRIPTION
In the CNC Shield v4 which is for the Arduino nano, the pins for direction are 2,3 and 4. The same way, the bits for step are 5,6 and 7. Uncommenting the definition for CNC_SHIELD_V4 in grbl/cpu_map.h make these changes