### PR TITLE
Grbl machine skew compensation

### DIFF
--- a/grbl/config.h
+++ b/grbl/config.h
@@ -699,7 +699,12 @@
 //    +-------------->X     +-------------->X     +-------------->Y
 //    XY_SKEW_FACTOR        XZ_SKEW_FACTOR        YZ_SKEW_FACTOR
 //
+
+//uncomment to enable skew compensation
 #define ENABLE_SKEW_COMPENSATION
+//if enabled skew compensations is done only for XY axis (saves CPU cycles)
+//uncomment to extend skew compensation for XZ axis and YZ axis as well
+//#define ALLAXIS_SKEW_COMPENSATION
 
 /* ---------------------------------------------------------------------------------------
    OEM Single File Configuration Option

--- a/grbl/config.h
+++ b/grbl/config.h
@@ -674,6 +674,32 @@
 // updating lots of code to ensure everything is running correctly.
 // #define DUAL_AXIS_CONFIG_CNC_SHIELD_CLONE  // Uncomment to select. Comment other configs.
 
+// Grbl machine machine skew compensation
+// This feature corrects for misalignment in the XYZ axes.
+//
+// Take the following steps to compute the skew in the XY plane:
+//   1. Print or draw a test square (e.g., https://www.thingiverse.com/thing:2563185)
+//   2. For XY_DIAG_AC measure the diagonal A to C
+//   3. For XY_DIAG_BD measure the diagonal B to D
+//   4. For XY_SIDE_AD measure the edge A to D
+//
+// Skew factors are computed and set manually via $37(XY), $38(XZ) and $39(YZ) parameters:
+//
+//   Compute AB     : SQRT(2*AC*AC+2*BD*BD-4*AD*AD)/2
+//   XY_SKEW_FACTOR : TAN(PI/2-ACOS((AC*AC-AB*AB-AD*AD)/(2*AB*AD)))
+//
+// If desired, follow the same procedure for XZ and YZ.
+// Use these diagrams for reference:
+// 
+//    Y                     Z                     Z
+//    ^     B-------C       ^     B-------C       ^     B-------C
+//    |    /       /        |    /       /        |    /       /
+//    |   /       /         |   /       /         |   /       /
+//    |  A-------D          |  A-------D          |  A-------D
+//    +-------------->X     +-------------->X     +-------------->Y
+//    XY_SKEW_FACTOR        XZ_SKEW_FACTOR        YZ_SKEW_FACTOR
+//
+#define ENABLE_SKEW_COMPENSATION
 
 /* ---------------------------------------------------------------------------------------
    OEM Single File Configuration Option

--- a/grbl/defaults.h
+++ b/grbl/defaults.h
@@ -63,6 +63,9 @@
   #define DEFAULT_HOMING_SEEK_RATE 500.0 // mm/min
   #define DEFAULT_HOMING_DEBOUNCE_DELAY 250 // msec (0-65k)
   #define DEFAULT_HOMING_PULLOFF 1.0 // mm
+  #define XY_SKEW_FACTOR 0.0
+  #define XZ_SKEW_FACTOR 0.0
+  #define YZ_SKEW_FACTOR 0.0
 #endif
 
 #ifdef DEFAULTS_SHERLINE_5400
@@ -105,6 +108,9 @@
   #define DEFAULT_HOMING_SEEK_RATE 635.0 // mm/min
   #define DEFAULT_HOMING_DEBOUNCE_DELAY 250 // msec (0-65k)
   #define DEFAULT_HOMING_PULLOFF 1.0 // mm
+  #define XY_SKEW_FACTOR 0.0
+  #define XZ_SKEW_FACTOR 0.0
+  #define YZ_SKEW_FACTOR 0.0
 #endif
 
 #ifdef DEFAULTS_POCKETNC_FR4
@@ -143,6 +149,9 @@
   #define DEFAULT_HOMING_SEEK_RATE 300.0 // mm/min
   #define DEFAULT_HOMING_DEBOUNCE_DELAY 250 // msec (0-65k)
   #define DEFAULT_HOMING_PULLOFF 3.0 // mm
+  #define XY_SKEW_FACTOR 0.0
+  #define XZ_SKEW_FACTOR 0.0
+  #define YZ_SKEW_FACTOR 0.0
 #endif
 
 #ifdef DEFAULTS_SHAPEOKO
@@ -188,6 +197,9 @@
   #define DEFAULT_HOMING_SEEK_RATE 250.0 // mm/min
   #define DEFAULT_HOMING_DEBOUNCE_DELAY 250 // msec (0-65k)
   #define DEFAULT_HOMING_PULLOFF 1.0 // mm
+  #define XY_SKEW_FACTOR 0.0
+  #define XZ_SKEW_FACTOR 0.0
+  #define YZ_SKEW_FACTOR 0.0
 #endif
 
 #ifdef DEFAULTS_SHAPEOKO_2
@@ -233,6 +245,9 @@
   #define DEFAULT_HOMING_SEEK_RATE 250.0 // mm/min
   #define DEFAULT_HOMING_DEBOUNCE_DELAY 250 // msec (0-65k)
   #define DEFAULT_HOMING_PULLOFF 1.0 // mm
+  #define XY_SKEW_FACTOR 0.0
+  #define XZ_SKEW_FACTOR 0.0
+  #define YZ_SKEW_FACTOR 0.0
 #endif
 
 #ifdef DEFAULTS_SHAPEOKO_3
@@ -277,6 +292,9 @@
   #define DEFAULT_HOMING_SEEK_RATE 1000.0 // mm/min
   #define DEFAULT_HOMING_DEBOUNCE_DELAY 25 // msec (0-65k)
   #define DEFAULT_HOMING_PULLOFF 5.0 // mm
+  #define XY_SKEW_FACTOR 0.0
+  #define XZ_SKEW_FACTOR 0.0
+  #define YZ_SKEW_FACTOR 0.0
 #endif
 
 #ifdef DEFAULTS_X_CARVE_500MM
@@ -322,6 +340,9 @@
   #define DEFAULT_HOMING_SEEK_RATE 750.0 // mm/min
   #define DEFAULT_HOMING_DEBOUNCE_DELAY 250 // msec (0-65k)
   #define DEFAULT_HOMING_PULLOFF 1.0 // mm
+  #define XY_SKEW_FACTOR 0.0
+  #define XZ_SKEW_FACTOR 0.0
+  #define YZ_SKEW_FACTOR 0.0
 #endif
 
 #ifdef DEFAULTS_X_CARVE_1000MM
@@ -367,6 +388,9 @@
   #define DEFAULT_HOMING_SEEK_RATE 750.0 // mm/min
   #define DEFAULT_HOMING_DEBOUNCE_DELAY 250 // msec (0-65k)
   #define DEFAULT_HOMING_PULLOFF 1.0 // mm
+  #define XY_SKEW_FACTOR 0.0
+  #define XZ_SKEW_FACTOR 0.0
+  #define YZ_SKEW_FACTOR 0.0
 #endif
 
 #ifdef DEFAULTS_BOBSCNC_E3
@@ -406,6 +430,9 @@
   #define DEFAULT_HOMING_SEEK_RATE 4000.0 // mm/min
   #define DEFAULT_HOMING_DEBOUNCE_DELAY 250 // msec (0-65k)
   #define DEFAULT_HOMING_PULLOFF 5.0 // mm
+  #define XY_SKEW_FACTOR 0.0
+  #define XZ_SKEW_FACTOR 0.0
+  #define YZ_SKEW_FACTOR 0.0
 #endif
 
 #ifdef DEFAULTS_BOBSCNC_E4
@@ -445,6 +472,9 @@
   #define DEFAULT_HOMING_SEEK_RATE 4000.0 // mm/min
   #define DEFAULT_HOMING_DEBOUNCE_DELAY 250 // msec (0-65k)
   #define DEFAULT_HOMING_PULLOFF 5.0 // mm
+  #define XY_SKEW_FACTOR 0.0
+  #define XZ_SKEW_FACTOR 0.0
+  #define YZ_SKEW_FACTOR 0.0
 #endif
 
 #ifdef DEFAULTS_ZEN_TOOLWORKS_7x7
@@ -488,6 +518,9 @@
   #define DEFAULT_HOMING_SEEK_RATE 250.0 // mm/min
   #define DEFAULT_HOMING_DEBOUNCE_DELAY 250 // msec (0-65k)
   #define DEFAULT_HOMING_PULLOFF 1.0 // mm
+  #define XY_SKEW_FACTOR 0.0
+  #define XZ_SKEW_FACTOR 0.0
+  #define YZ_SKEW_FACTOR 0.0
 #endif
 
 #ifdef DEFAULTS_OXCNC
@@ -527,6 +560,9 @@
   #define DEFAULT_HOMING_SEEK_RATE 500.0 // mm/min
   #define DEFAULT_HOMING_DEBOUNCE_DELAY 250 // msec (0-65k)
   #define DEFAULT_HOMING_PULLOFF 1.0 // mm
+  #define XY_SKEW_FACTOR 0.0
+  #define XZ_SKEW_FACTOR 0.0
+  #define YZ_SKEW_FACTOR 0.0
 #endif
 
 #ifdef DEFAULTS_SIMULATOR
@@ -566,6 +602,9 @@
   #define DEFAULT_HOMING_SEEK_RATE 500.0 // mm/min
   #define DEFAULT_HOMING_DEBOUNCE_DELAY 250 // msec (0-65k)
   #define DEFAULT_HOMING_PULLOFF 1.0 // mm
+  #define XY_SKEW_FACTOR 0.0
+  #define XZ_SKEW_FACTOR 0.0
+  #define YZ_SKEW_FACTOR 0.0
 #endif
 
 #endif

--- a/grbl/motion_control.c
+++ b/grbl/motion_control.c
@@ -66,8 +66,11 @@ void mc_line(float *target, plan_line_data_t *pl_data)
 
   #ifdef ENABLE_SKEW_COMPENSATION
     //apply correction skew factors that compensate for machine axis alignemnt
-    target[X_AXIS] -= target[Y_AXIS] * settings.xy_skew_factor + target[Z_AXIS] * (settings.xy_skew_factor - settings.xz_skew_factor * settings.yz_skew_factor);
-    target[Y_AXIS] -= target[Z_AXIS] * settings.yz_skew_factor;
+    target[X_AXIS] -= target[Y_AXIS] * settings.xy_skew_factor;
+    #ifdef ALLAXIS_SKEW_COMPENSATION
+      target[X_AXIS] -= target[Z_AXIS] * (settings.xy_skew_factor - settings.xz_skew_factor * settings.yz_skew_factor);
+      target[Y_AXIS] -= target[Z_AXIS] * settings.yz_skew_factor;
+    #endif
   #endif
 
   // Plan and queue motion into planner buffer

--- a/grbl/motion_control.c
+++ b/grbl/motion_control.c
@@ -64,6 +64,12 @@ void mc_line(float *target, plan_line_data_t *pl_data)
     else { break; }
   } while (1);
 
+  #ifdef ENABLE_SKEW_COMPENSATION
+    //apply correction skew factors that compensate for machine axis alignemnt
+    target[X_AXIS] -= target[Y_AXIS] * settings.xy_skew_factor + target[Z_AXIS] * (settings.xy_skew_factor - settings.xz_skew_factor * settings.yz_skew_factor);
+    target[Y_AXIS] -= target[Z_AXIS] * settings.yz_skew_factor;
+  #endif
+
   // Plan and queue motion into planner buffer
   if (plan_buffer_line(target, pl_data) == PLAN_EMPTY_BLOCK) {
     if (bit_istrue(settings.flags,BITFLAG_LASER_MODE)) {

--- a/grbl/report.c
+++ b/grbl/report.c
@@ -212,8 +212,10 @@ void report_grbl_settings() {
 
   #ifdef ENABLE_SKEW_COMPENSATION
     report_util_float_setting(37,settings.xy_skew_factor,N_DECIMAL_SETTINGVALUE);
-    report_util_float_setting(38,settings.xz_skew_factor,N_DECIMAL_SETTINGVALUE);
-    report_util_float_setting(39,settings.yz_skew_factor,N_DECIMAL_SETTINGVALUE);
+    #ifdef ALLAXIS_SKEW_COMPENSATION
+      report_util_float_setting(38,settings.xz_skew_factor,N_DECIMAL_SETTINGVALUE);
+      report_util_float_setting(39,settings.yz_skew_factor,N_DECIMAL_SETTINGVALUE);
+    #endif
   #endif
   
   // Print axis settings

--- a/grbl/report.c
+++ b/grbl/report.c
@@ -203,11 +203,19 @@ void report_grbl_settings() {
   report_util_float_setting(27,settings.homing_pulloff,N_DECIMAL_SETTINGVALUE);
   report_util_float_setting(30,settings.rpm_max,N_DECIMAL_RPMVALUE);
   report_util_float_setting(31,settings.rpm_min,N_DECIMAL_RPMVALUE);
+  
   #ifdef VARIABLE_SPINDLE
     report_util_uint8_setting(32,bit_istrue(settings.flags,BITFLAG_LASER_MODE));
   #else
     report_util_uint8_setting(32,0);
   #endif
+
+  #ifdef ENABLE_SKEW_COMPENSATION
+    report_util_float_setting(37,settings.xy_skew_factor,N_DECIMAL_SETTINGVALUE);
+    report_util_float_setting(38,settings.xz_skew_factor,N_DECIMAL_SETTINGVALUE);
+    report_util_float_setting(39,settings.yz_skew_factor,N_DECIMAL_SETTINGVALUE);
+  #endif
+  
   // Print axis settings
   uint8_t idx, set_idx;
   uint8_t val = AXIS_SETTINGS_START_VAL;

--- a/grbl/settings.c
+++ b/grbl/settings.c
@@ -38,9 +38,13 @@ const __flash settings_t defaults = {\
     .homing_seek_rate = DEFAULT_HOMING_SEEK_RATE,
     .homing_debounce_delay = DEFAULT_HOMING_DEBOUNCE_DELAY,
     .homing_pulloff = DEFAULT_HOMING_PULLOFF,
-    .xy_skew_factor = XY_SKEW_FACTOR,
-    .xz_skew_factor = XZ_SKEW_FACTOR,
-    .yz_skew_factor = YZ_SKEW_FACTOR,
+    #ifdef ENABLE_SKEW_COMPENSATION
+      .xy_skew_factor = XY_SKEW_FACTOR,
+      #ifdef ALLAXIS_SKEW_COMPENSATION
+        .xz_skew_factor = XZ_SKEW_FACTOR,
+        .yz_skew_factor = YZ_SKEW_FACTOR,
+      #endif
+    #endif 
     .flags = (DEFAULT_REPORT_INCHES << BIT_REPORT_INCHES) | \
              (DEFAULT_LASER_MODE << BIT_LASER_MODE) | \
              (DEFAULT_INVERT_ST_ENABLE << BIT_INVERT_ST_ENABLE) | \
@@ -299,8 +303,10 @@ uint8_t settings_store_global_setting(uint8_t parameter, float value) {
         break;
       #ifdef ENABLE_SKEW_COMPENSATION
         case 37: settings.xy_skew_factor = value; break;
-        case 38: settings.xz_skew_factor = value; break;
-        case 39: settings.yz_skew_factor = value; break;
+        #ifdef ALLAXIS_SKEW_COMPENSATION
+          case 38: settings.xz_skew_factor = value; break;
+          case 39: settings.yz_skew_factor = value; break;
+        #endif
       #endif
       default:
         return(STATUS_INVALID_STATEMENT);

--- a/grbl/settings.c
+++ b/grbl/settings.c
@@ -38,6 +38,9 @@ const __flash settings_t defaults = {\
     .homing_seek_rate = DEFAULT_HOMING_SEEK_RATE,
     .homing_debounce_delay = DEFAULT_HOMING_DEBOUNCE_DELAY,
     .homing_pulloff = DEFAULT_HOMING_PULLOFF,
+    .xy_skew_factor = XY_SKEW_FACTOR,
+    .xz_skew_factor = XZ_SKEW_FACTOR,
+    .yz_skew_factor = YZ_SKEW_FACTOR,
     .flags = (DEFAULT_REPORT_INCHES << BIT_REPORT_INCHES) | \
              (DEFAULT_LASER_MODE << BIT_LASER_MODE) | \
              (DEFAULT_INVERT_ST_ENABLE << BIT_INVERT_ST_ENABLE) | \
@@ -294,6 +297,11 @@ uint8_t settings_store_global_setting(uint8_t parameter, float value) {
           return(STATUS_SETTING_DISABLED_LASER);
         #endif
         break;
+      #ifdef ENABLE_SKEW_COMPENSATION
+        case 37: settings.xy_skew_factor = value; break;
+        case 38: settings.xz_skew_factor = value; break;
+        case 39: settings.yz_skew_factor = value; break;
+      #endif
       default:
         return(STATUS_INVALID_STATEMENT);
     }

--- a/grbl/settings.h
+++ b/grbl/settings.h
@@ -110,9 +110,13 @@ typedef struct {
   float homing_seek_rate;
   uint16_t homing_debounce_delay;
   float homing_pulloff;
-  float xy_skew_factor;
-  float xz_skew_factor;
-  float yz_skew_factor;
+  #ifdef ENABLE_SKEW_COMPENSATION
+    float xy_skew_factor;
+    #ifdef ALLAXIS_SKEW_COMPENSATION
+      float xz_skew_factor;
+      float yz_skew_factor;
+    #endif
+  #endif
 } settings_t;
 extern settings_t settings;
 

--- a/grbl/settings.h
+++ b/grbl/settings.h
@@ -27,7 +27,7 @@
 
 // Version of the EEPROM data. Will be used to migrate existing data from older versions of Grbl
 // when firmware is upgraded. Always stored in byte 0 of eeprom
-#define SETTINGS_VERSION 10  // NOTE: Check settings_reset() when moving to next version.
+#define SETTINGS_VERSION 11  // NOTE: Check settings_reset() when moving to next version.
 
 // Define bit flag masks for the boolean settings in settings.flag.
 #define BIT_REPORT_INCHES      0
@@ -110,6 +110,9 @@ typedef struct {
   float homing_seek_rate;
   uint16_t homing_debounce_delay;
   float homing_pulloff;
+  float xy_skew_factor;
+  float xz_skew_factor;
+  float yz_skew_factor;
 } settings_t;
 extern settings_t settings;
 

--- a/grbl/system.c
+++ b/grbl/system.c
@@ -302,6 +302,7 @@ float system_convert_axis_steps_to_mpos(int32_t *steps, uint8_t idx)
   #else
     pos = steps[idx]/settings.steps_per_mm[idx];
   #endif
+
   return(pos);
 }
 
@@ -312,6 +313,16 @@ void system_convert_array_steps_to_mpos(float *position, int32_t *steps)
   for (idx=0; idx<N_AXIS; idx++) {
     position[idx] = system_convert_axis_steps_to_mpos(steps, idx);
   }
+
+  //perform unskew of the coordinates
+  #ifdef ENABLE_SKEW_COMPENSATION
+    position[X_AXIS] += position[Y_AXIS] * settings.xy_skew_factor;
+    #ifdef ALLAXIS_SKEW_COMPENSATION
+      position[X_AXIS] += position[Z_AXIS] * settings.xz_skew_factor;
+      position[Y_AXIS] += position[Z_AXIS] * settings.yz_skew_factor;
+    #endif
+  #endif
+
   return;
 }
 


### PR DESCRIPTION
Implemention of grbl axis skew compensation.
Axis skew compensation is enabled in config.h. By default only XY skew is enabled.
Axis pair XZ or YZ skew compensation calculations are optional and also configurable on config.h

Compensation is done by computing the current axis position and applying a given factor for each pair of axis. The formula for the compensation factor is explained in the config.h file.
When reporting the current position the inverse transformation is also applied.

The skew factors are saved in EEPROM configuration words $37(XY), $38(XZ) and $39(YZ).