### PR TITLE
Fixed Homing state bug

### DIFF
--- a/grbl/system.c
+++ b/grbl/system.c
@@ -179,12 +179,13 @@ uint8_t system_execute_line(char *line)
         case 'H' : // Perform homing cycle [IDLE/ALARM]
           if (bit_isfalse(settings.flags,BITFLAG_HOMING_ENABLE)) {return(STATUS_SETTING_DISABLED); }
           if (system_check_safety_door_ajar()) { return(STATUS_CHECK_DOOR); } // Block if safety door is ajar.
-          sys.state = STATE_HOMING; // Set system state variable
           if (line[2] == 0) {
+            sys.state = STATE_HOMING; // Set system state variable
             mc_homing_cycle(HOMING_CYCLE_ALL);
           #ifdef HOMING_SINGLE_AXIS_COMMANDS
             } else if (line[3] == 0) {
               switch (line[2]) {
+                sys.state = STATE_HOMING; // Set system state variable
                 case 'X': mc_homing_cycle(HOMING_CYCLE_X); break;
                 case 'Y': mc_homing_cycle(HOMING_CYCLE_Y); break;
                 case 'Z': mc_homing_cycle(HOMING_CYCLE_Z); break;


### PR DESCRIPTION
Fixed an issue where grbl's state machine gets corrupted.  For example, if "$H0abc" is sent, existing grbl sets sys.state=STATE_HOMING, but then bails out without actually homing.  Subsequent "$H" commands are then not executed, because grbl isn't idle (it still thinks it's homing).

Moving sys.state=STATE_HOMING to after the conditional prevents grbl from getting stuck in homing state.