### PR TITLE
Enable platformio support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,8 @@
 *.DS_Store
 *.d
 
+.pio
+.vscode
+
 README.md
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,9 @@
+[platformio]
+src_dir=grbl
+
+[env:uno]
+platform=atmelavr
+board=uno
+framework=arduino
+
+monitor_speed=115200


### PR DESCRIPTION
This PR adds a simple `platform.io` file that builds a file for Arduino Uno. Its output exactly matches what Arduino IDE creates.

Having platformio file in this repo allows developers to use "normal" IDEs with autocomplete, refactoring and stuff, while maintaining Arduino compatibility. It also will allow easy autobuilding of release builds with CI/CD pipelines (with pio CLI).

Full compatibility with Arduino IDE is retained (it still works)