### PR TITLE
Fix defaults.h include guard

### DIFF
--- a/grbl/defaults.h
+++ b/grbl/defaults.h
@@ -26,6 +26,7 @@
    NOTE: Ensure one and only one of these DEFAULTS_XXX values is defined in config.h */
 
 #ifndef defaults_h
+#define defaults_h
 
 #ifdef DEFAULTS_GENERIC
   // Grbl generic default settings. Should work across different machines.


### PR DESCRIPTION
While `defaults.h` checked for a `defaults_h` define to be present, it does not declare such a define. Thus it's easy to mess up including the file twice.