### PR TITLE
Fixed issue with jog after probe.

### DIFF
--- a/grbl/motion_control.c
+++ b/grbl/motion_control.c
@@ -313,6 +313,8 @@ uint8_t mc_probe_cycle(float *target, plan_line_data_t *pl_data, uint8_t parser_
     report_probe_parameters();
   #endif
 
+  sys.step_control = STEP_CONTROL_NORMAL_OP; // Restore step control to normal operation
+
   if (sys.probe_succeeded) { return(GC_PROBE_FOUND); } // Successful probe cycle.
   else { return(GC_PROBE_FAIL_END); } // Failed to trigger probe within travel. With or without error.
 }


### PR DESCRIPTION
After successful probe (G38.2 Z-20 F100) step control is blocked by STEP_CONTROL_END_MOTION flag. It blocks stepper prepare buffer and after jog action ($J=G91Z1F10) it is immediately turns to Idle and then to Run state. Although stepper actions are correct it is impossible to stop this jog action (see [Candle #542](https://github.com/Denvi/Candle/issues/542) ).