### PR TITLE
Replace incorrect board name in list of supported boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ***
 _Click the `Release` tab to download pre-compiled `.hex` files or just [click here](https://github.com/gnea/grbl/releases)_
 ***
-Grbl is a no-compromise, high performance, low cost alternative to parallel-port-based motion control for CNC milling. This version of Grbl runs on an Arduino with a 328p processor (Uno, Duemilanove, Nano, Micro, etc).
+Grbl is a no-compromise, high performance, low cost alternative to parallel-port-based motion control for CNC milling. This version of Grbl runs on an Arduino with a 328p processor (Uno, Duemilanove, Nano, Pro Mini, etc).
 
 The controller is written in highly optimized C utilizing every clever feature of the AVR-chips to achieve precise timing and asynchronous operation. It is able to maintain up to 30kHz of stable, jitter free control pulses.
 


### PR DESCRIPTION
The readme specifies the project's target of ATmega328P-based boards and includes a list of examples of such boards.

Previously that list included the [**Micro**](https://docs.arduino.cc/hardware/micro), but this board is based on the ATmega32U4 microcontroller rather than ATmega328P. From experience, I know that people often mix up the names of the "Micro"/"[**Pro Micro**](https://www.sparkfun.com/products/12640)" and the similarly named and formed "[**Pro Mini**](https://learn.sparkfun.com/tutorials/using-the-arduino-pro-mini-33v)", which is a common ATmega328P-based board. So I replaced the incorrect mention of "Micro" with "Pro Mini".