### PR TITLE
Added an option HOMING_SET_ORIGIN_AFTER_PULLOFF

### DIFF
--- a/grbl/config.h
+++ b/grbl/config.h
@@ -128,6 +128,15 @@
 // define to force Grbl to always set the machine origin at the homed location despite switch orientation.
 // #define HOMING_FORCE_SET_ORIGIN // Uncomment to enable.
 
+// By default, Grbl sets the machine origin to zero at the exact point where the homing switches first
+// make contact, then moves away from the switch by the homing pulloff distance given in setting 27.
+// Even with soft limits enabled, this does not prevent the operator subsequently jogging right up to
+// the machine origin and possibly triggering the limit switch. This option instead sets the machine
+// origin to zero after it has performed the pulloff move, so that soft limits won't allow the machine
+// to be jogged any closer to the limit switch than the pulloff distance.
+// Note: this setting is ignored if HOMING_FORCE_SET_ORIGIN is enabled.
+// #define HOMING_SET_ORIGIN_AFTER_PULLOFF
+
 // Number of blocks Grbl executes upon startup. These blocks are stored in EEPROM, where the size
 // and addresses are defined in settings.h. With the current settings, up to 2 startup blocks may
 // be stored and executed in order. These startup blocks would typically be used to set the g-code

--- a/grbl/limits.c
+++ b/grbl/limits.c
@@ -376,11 +376,22 @@ void limits_go_home(uint8_t cycle_mask)
       #ifdef HOMING_FORCE_SET_ORIGIN
         set_axis_position = 0;
       #else
+      #ifdef HOMING_SET_ORIGIN_AFTER_PULLOFF
+        if ( bit_istrue(settings.homing_dir_mask,bit(idx)) ) {
+	  // Round up (i.e. away from the limit) to avoid a situation where a later
+	  // rounding error sometimes causes the axis position after homing to be a tiny
+	  // amount past max_travel, which immediately triggers its soft limit.
+	  set_axis_position = lround(ceil(settings.max_travel[idx]*settings.steps_per_mm[idx]));
+        } else {
+          set_axis_position = 0;
+        }
+      #else
         if ( bit_istrue(settings.homing_dir_mask,bit(idx)) ) {
           set_axis_position = lround((settings.max_travel[idx]+settings.homing_pulloff)*settings.steps_per_mm[idx]);
         } else {
           set_axis_position = lround(-settings.homing_pulloff*settings.steps_per_mm[idx]);
         }
+      #endif
       #endif
 
       #ifdef COREXY


### PR DESCRIPTION
This option sets the machine position to zero (or max_travel if homing direction is inverted) after instead of before performing the homing pulloff move. When soft limits are enabled, this provides a virtual buffer zone between the machine's 0 and the hardware limit switch that prevents the operator being able to jog right up to the switch and potentially accidentally trigger a hard limit alarm.