### PR TITLE
Automatically limiting Z travel distance to soft limits during Z probing

### DIFF
--- a/grbl/motion_control.c
+++ b/grbl/motion_control.c
@@ -277,6 +277,9 @@ uint8_t mc_probe_cycle(float *target, plan_line_data_t *pl_data, uint8_t parser_
     return(GC_PROBE_FAIL_INIT); // Nothing else to do but bail.
   }
 
+  // Z Probing simplification : if Z travel exceeds soft limits, adjust Z to max. allowed value as probing stop is anyhow expected
+  system_do_limit_Z_travel(target);
+  
   // Setup and queue probing motion. Auto cycle-start should not start the cycle.
   mc_line(target, pl_data);
 

--- a/grbl/system.c
+++ b/grbl/system.c
@@ -351,6 +351,24 @@ uint8_t system_check_travel_limits(float *target)
   return(false);
 }
 
+// Z Probing simplification : if Z travel exceeds soft limits, adjust Z to max. allowed value as probing stop is anyhow expected
+// function code derived from above soft limit check
+uint8_t system_do_limit_Z_travel(float *target)
+{
+    #ifdef HOMING_FORCE_SET_ORIGIN
+      // When homing forced set origin is enabled, soft limits checks need to account for directionality.
+      // NOTE: max_travel is stored as negative
+      if (bit_istrue(settings.homing_dir_mask,bit(Z_AXIS))) {
+        if (target[Z_AXIS] < 0 || target[Z_AXIS] > -settings.max_travel[Z_AXIS]) { target[Z_AXIS] = -settings.max_travel[Z_AXIS]; return(true); }
+      } else {
+        if (target[Z_AXIS] > 0 || target[Z_AXIS] <  settings.max_travel[Z_AXIS]) { target[Z_AXIS] =  settings.max_travel[Z_AXIS]; return(true); }
+      }
+    #else
+      // NOTE: max_travel is stored as negative
+        if (target[Z_AXIS] > 0 || target[Z_AXIS] <  settings.max_travel[Z_AXIS]) { target[Z_AXIS] =  settings.max_travel[Z_AXIS]; return(true); }
+    #endif
+  return(false);
+}
 
 // Special handlers for setting and clearing Grbl's real-time execution flags.
 void system_set_exec_state_flag(uint8_t mask) {

--- a/grbl/system.h
+++ b/grbl/system.h
@@ -198,6 +198,9 @@ void system_convert_array_steps_to_mpos(float *position, int32_t *steps);
 // Checks and reports if target array exceeds machine travel limits.
 uint8_t system_check_travel_limits(float *target);
 
+// Z Probing simplification : if Z travel exceeds soft limits, adjust Z to max. allowed value as probing stop is anyhow expected
+uint8_t system_do_limit_Z_travel(float *target);
+
 // Special handlers for setting and clearing Grbl's real-time execution flags.
 void system_set_exec_state_flag(uint8_t mask);
 void system_clear_exec_state_flag(uint8_t mask);


### PR DESCRIPTION
When performing Z probing for PCB engraving I often ran into the problem that the G38.2Z command caused a soft limit violation, accompanied by the requirement to perform a new homing cycle.
During Z probing the given Z distance in the G38.2Z command is anyhow not expected to be reached.
Instead the Z probe making contact with the PCB stops travel immediately.
So why not making Z probing more intelligent and avoiding soft limit violations ?

I implemented an automatic limiting of Z travel distance during Z probing. In case Z travel would exceed the soft limits, the Z movement is limited to the Z soft limit. Thus a soft limit error is avoided and the travel does not exceed the soft limit values.

Now I can start at any height a simple Z probing, without running into soft limit violations.

Example for my machine which has Z soft limit of 80: 
G21G91G38.2Z-99F100

The given distance value -99 is automatically set to 80 during probing, i.e. no soft limit error will be triggered.

I have seen that other GRBL users are disabling the soft limits during Z probing to avoid the limit error.
My proposed solution is safer as limits are still in place.